### PR TITLE
Update requested sbt version to make it able to fetch scala-xml in the right place.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.0


### PR DESCRIPTION
Sbinary used sbt 0.12.4 which has the wrong default for scalaBinaryVersion for
Scala milestones. This requires sbt 0.13.0 for the build, making it fetch
scala-xml at a URI that takes the full
_milestone_ version string into account.
