### PR TITLE
Compile on 2.11, introduce settings for dependency versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: scala
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION update compile # TODO: test when scalacheck dependency is enabled
+scala:
+  - 2.10.3
+  - 2.11.0-M6
+jdk:
+  - oraclejdk6
+  - openjdk7
+notifications:
+  email:
+    - qbranch@typesafe.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION update compile # TODO: test when scalacheck dependency is enabled
+  - sbt ++$TRAVIS_SCALA_VERSION 'set every includeTestDependencies := true' update test
 scala:
   - 2.10.3
   - 2.11.0-M6

--- a/core/test-src/binaryTests.scala
+++ b/core/test-src/binaryTests.scala
@@ -141,7 +141,10 @@ object FormatTests extends Properties("Formats"){
   implicit def arbitraryArray[T](implicit arb : Arbitrary[T], mf: scala.reflect.Manifest[T]) : Arbitrary[Array[T]] =
      Arbitrary(arbitrary[List[T]].map((x : List[T]) => x.toArray[T]));
 
-  implicit val arbitraryEnumeration : Arbitrary[Enumeration] = Arbitrary(arbitrary[List[String]].map(x => new Enumeration(x : _*){}));
+  implicit val arbitraryEnumeration : Arbitrary[Enumeration] =
+    Arbitrary(arbitrary[List[String]].map(names => new Enumeration {
+      names foreach Value
+    }))
 
   implicit def orderedOption[T](opt : Option[T])(implicit ord : Ordering[T]) : Ordered[Option[T]] = new Ordered[Option[T]]{
     def compare(that : Option[T]) = (opt, that) match {
@@ -173,7 +176,7 @@ object FormatTests extends Properties("Formats"){
 
   sealed abstract class BinaryTree;
   case class Split(left : BinaryTree, right : BinaryTree) extends BinaryTree;
-  case class Leaf extends BinaryTree;
+  case class Leaf() extends BinaryTree;
 
   implicit val eqBinaryTree = allAreEqual[BinaryTree]
 

--- a/project/SBinaryProject.scala
+++ b/project/SBinaryProject.scala
@@ -9,29 +9,35 @@ object SBinaryProject extends Build
 
 	lazy val commonSettings: Seq[Setting[_]] = Seq(
 		organization := "org.scala-tools.sbinary",
-		version := "0.4.2",
-		scalaVersion := "2.11.0-M4",
+		version := "0.4.3-SNAPSHOT",
+		scalaVersion := "2.11.0-M6",
 		crossVersion := CrossVersion.full,
+		scalaXmlVersion := "1.0.0-RC6",
+		scalaParserCombinatorsVersion := "1.0.0-RC4",
+		scalaCheckVersion := "1.10.1",
 		includeTestDependencies <<= scalaVersion(_.startsWith("2.10."))
 	)
 
+	lazy val scalaXmlVersion = SettingKey[String]("scala-xml-version")
+	lazy val scalaParserCombinatorsVersion = SettingKey[String]("scala-parser-combinators-version")
+	lazy val scalaCheckVersion = SettingKey[String]("scalacheck-version")
+
 	lazy val includeTestDependencies = SettingKey[Boolean]("include-test-dependencies")
-	lazy val scalaCheck = libraryDependencies <++= includeTestDependencies( incl =>
-		if(incl)
-			List("org.scalacheck" %% "scalacheck" % "1.10.0" % "test")
-		else
-			Nil
-	)
+
 	lazy val coreSettings = commonSettings ++ template ++ Seq(
 		name := "SBinary",
-		scalaCheck,
-		libraryDependencies <++= scalaVersion(scalaXmlDep),
+		libraryDependencies ++= (
+			if(includeTestDependencies.value) Seq(
+				"org.scalacheck" %% "scalacheck" % scalaCheckVersion.value % "test" intransitive)
+			else Nil ),
+		libraryDependencies ++= (
+			if(scalaVersion.value.startsWith("2.11.")) Seq(
+				"org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion.value,
+				"org.scala-lang.modules" %% "scala-parser-combinators" % scalaParserCombinatorsVersion.value)
+			else Nil ),
 		unmanagedResources in Compile <+= baseDirectory map { _ / "LICENSE" }
 	)
 	def aux(nameString: String) = commonSettings ++ Seq( publish := (), name := nameString )
-
-	def scalaXmlDep(scalaV: String): List[ModuleID] =
-		if(scalaV.startsWith("2.11.")) List("org.scala-lang.modules" %% "scala-xml" % "1.0-RC2") else Nil
 
 	/*** Templating **/
 

--- a/project/SBinaryProject.scala
+++ b/project/SBinaryProject.scala
@@ -15,6 +15,7 @@ object SBinaryProject extends Build
 		scalaXmlVersion := "1.0.0-RC6",
 		scalaParserCombinatorsVersion := "1.0.0-RC4",
 		scalaCheckVersion := "1.10.1",
+		resolvers += Resolver.sonatypeRepo("snapshots"), // to allow compiling against snapshot versions of Scala
 		includeTestDependencies <<= scalaVersion(_.startsWith("2.10."))
 	)
 


### PR DESCRIPTION
Bump version and make it a snap!shot to 0.4.3-SNAPSHOT.
(Build's version should end in -SNAPSHOT for nightly).

Depend on parser combinators for tests.
Rework Arbitrary instance for Enumeration.

review by @harrah
