### PR TITLE
Decouple includeTestDependencies and scalaVersion

### DIFF
--- a/project/SBinaryProject.scala
+++ b/project/SBinaryProject.scala
@@ -16,7 +16,7 @@ object SBinaryProject extends Build
 		scalaParserCombinatorsVersion := "1.0.0-RC5",
 		scalaCheckVersion := "1.11.1",
 		resolvers += Resolver.sonatypeRepo("snapshots"), // to allow compiling against snapshot versions of Scala
-		includeTestDependencies <<= scalaVersion(_.startsWith("2.10."))
+		includeTestDependencies := true
 	)
 
 	lazy val scalaXmlVersion = SettingKey[String]("scala-xml-version")


### PR DESCRIPTION
Working on cleaning up https://github.com/typesafehub/sbt-builds-for-ide. Separate PR to follow that allows for this current PR.

Since we're now building scalacheck, we might as well test sbinary.
