### PR TITLE
Bump sbt version to 0.13.5

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.5


### PR DESCRIPTION
This is a minimal change to make sbinary buildable with dbuild 0.9.x
https://github.com/typesafehub/dbuild
